### PR TITLE
Fake gripper simulateMove timing without goroutine

### DIFF
--- a/fakegripper/gripper.go
+++ b/fakegripper/gripper.go
@@ -51,7 +51,7 @@ func newFakeGripper(ctx context.Context, deps resource.Dependencies, conf resour
 	return f, nil
 }
 
-func (f *fake) simulateMove(ctx context.Context, extra map[string]interface{}) error {
+func (f *fake) simulateMove() error {
 	var moveCtx context.Context
 	{
 		f.mu.Lock()

--- a/fakegripper/gripper.go
+++ b/fakegripper/gripper.go
@@ -51,11 +51,11 @@ func newFakeGripper(ctx context.Context, deps resource.Dependencies, conf resour
 	return f, nil
 }
 
-func (f *fake) simulateMove() error {
+func (f *fake) simulateMove(ctx context.Context) error {
 	var moveCtx context.Context
 	{
 		f.mu.Lock()
-		moveCtx, f.stopmoving = context.WithTimeout(context.Background(), 2*time.Second)
+		moveCtx, f.stopmoving = context.WithTimeout(ctx, 2*time.Second)
 		f.moving = true
 		f.mu.Unlock()
 	}
@@ -72,11 +72,11 @@ func (f *fake) simulateMove() error {
 }
 
 func (f *fake) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
-	return true, f.simulateMove(ctx, extra)
+	return true, f.simulateMove(ctx)
 }
 
 func (f *fake) Open(ctx context.Context, extra map[string]interface{}) error {
-	return f.simulateMove(ctx, extra)
+	return f.simulateMove(ctx)
 }
 
 func (f *fake) Stop(context.Context, map[string]interface{}) error {


### PR DESCRIPTION
Change fake gripper to not use a goroutine for simulateMove.

Otherwise `Grab` returns instantly because simulateMove returns before the goroutine to start moving actually starts


Not sure how you want to manage commits to this repo 